### PR TITLE
Enable using tables in Markdown

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -43,6 +43,7 @@ markdown_extras = [
     "fenced-code-blocks",
     "header-ids",
     "mermaid",
+    "tables",
 ]
 
 


### PR DESCRIPTION
Hi Jay!

This fixes the bug where tables weren't being rendered. I tested it locally.

Python-Markdown2 does support tables, but they aren't enabled by default – you have to enable them [as an "extra"](https://github.com/trentm/python-markdown2/wiki/Extras). Adding the `table` extra got the tables to appear in a local build.